### PR TITLE
feat(experimental): add relevance validation for retrieved passages

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,12 +50,16 @@ python src/main.py
 
 ```
 .
-├── docs/                # Vos fichiers Markdown
-├── src/                 # Code source
-│   └── main.py         # Script principal
-├── chroma_db/          # Base de données vectorielle (généré)
-├── requirements.txt    # Dépendances Python
-└── README.md          # Ce fichier
+├── docs/                    # Vos fichiers Markdown
+├── src/                    # Code source
+│   ├── main.py            # Script principal
+│   ├── config.py          # Configuration et initialisation
+│   ├── markdown_processor.py   # Traitement des fichiers Markdown
+│   ├── prompts.py         # Prompts système
+│   └── query_engine.py    # Moteur de requête et validation
+├── chroma_db/             # Base de données vectorielle (généré)
+├── requirements.txt       # Dépendances Python
+└── README.md             # Ce fichier
 ```
 
 ---
@@ -108,15 +112,14 @@ python src/main.py
 
 ```
 .
-├── docs/                # Your Markdown files
-├── src/                 # Source code
-│   └── main.py         # Main script
-├── chroma_db/          # Vector database (generated)
-├── requirements.txt    # Python dependencies
-└── README.md          # This file
+├── docs/                    # Your Markdown files
+├── src/                    # Source code
+│   ├── main.py            # Main script
+│   ├── config.py          # Configuration and initialization
+│   ├── markdown_processor.py   # Markdown file processing
+│   ├── prompts.py         # System prompts
+│   └── query_engine.py    # Query engine and validation
+├── chroma_db/             # Vector database (generated)
+├── requirements.txt       # Python dependencies
+└── README.md             # This file
 ```
-
-### 🤝 Contributing
-
-Feel free to open issues and pull requests!
-

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,36 @@
+"""
+Module de configuration du système RAG.
+Contient l'initialisation des modèles et les paramètres globaux.
+
+RAG system configuration module.
+Contains model initialization and global parameters.
+"""
+
+from llama_index.core import Settings
+from llama_index.llms.ollama import Ollama
+from llama_index.embeddings.huggingface import HuggingFaceEmbedding
+
+# Initialize embedding model using HuggingFace's all-mpnet-base-v2
+EMBEDDING_MODEL = HuggingFaceEmbedding(
+    model_name="sentence-transformers/all-mpnet-base-v2"
+)
+
+# Initialize local LLM using Ollama
+# timeout set to 120s due to the large model size (70B parameters)
+# You can change the model
+# LLM = Ollama(model="llama3.3:70b-instruct-q6_K", request_timeout=120.0)
+# LLM = Ollama(model="llama3.3:70b-instruct-q5_0", request_timeout=120.0)
+LLM = Ollama(model="llama3.3:70b-instruct-q3_K_M", request_timeout=120.0)
+
+# Global RAG settings
+CHUNK_SIZE = 2048  # Large chunks to maintain context and section coherence
+CHUNK_OVERLAP = 128  # Overlap between chunks to avoid losing context at boundaries
+TOP_K = 8  # Number of relevant chunks to use
+
+
+def init_settings():
+    """Initialize global LlamaIndex settings"""
+    Settings.llm = LLM
+    Settings.embed_model = EMBEDDING_MODEL
+    Settings.chunk_size = CHUNK_SIZE
+    Settings.chunk_overlap = CHUNK_OVERLAP

--- a/src/main.py
+++ b/src/main.py
@@ -1,142 +1,40 @@
-from llama_index.core import Document, VectorStoreIndex, Settings
-from llama_index.llms.ollama import Ollama
-from llama_index.embeddings.huggingface import HuggingFaceEmbedding
-from pathlib import Path
+"""
+Point d'entrée principal du système RAG.
+Gère l'interaction avec l'utilisateur et orchestre les différents composants.
 
-# Initialize embedding model using HuggingFace's all-mpnet-base-v2
-# This model provides better semantic understanding compared to simpler models
-embed_model = HuggingFaceEmbedding(model_name="sentence-transformers/all-mpnet-base-v2")
+Main entry point of the RAG system.
+Handles user interaction and orchestrates different components.
+"""
 
-# Initialize local LLM using Ollama
-# timeout set to 120s due to the large model size (70B parameters)
-# You can change the model
-llm = Ollama(model="llama3.3:70b-instruct-q6_K", request_timeout=120.0)
-
-# Global settings for the RAG system
-Settings.llm = llm
-Settings.embed_model = embed_model
-Settings.chunk_size = 2048  # Large chunks to maintain context and section coherence
-Settings.chunk_overlap = (
-    128  # Overlap between chunks to avoid losing context at boundaries
-)
-
-
-def split_markdown_by_headers(content: str, source_path: str) -> list[Document]:
-    """
-    Enhanced markdown content splitter that preserves hierarchy and handles code blocks.
-    Only splits at level 2 headers (##) but preserves subheaders in content.
-
-    Args:
-        content: Raw markdown content
-        source_path: Path to the source file
-    Returns:
-        List of Document objects
-    """
-    documents = []
-    current_section = []
-    current_title = "Introduction"  # Default title if section doesn't have title
-    in_code_block = False
-
-    for line in content.split("\n"):
-        # Handle code blocks
-        if line.startswith("```"):
-            in_code_block = not in_code_block
-            current_section.append(line)
-            continue
-
-        if in_code_block:
-            current_section.append(line)
-            continue
-
-        # Only split on level 2 headers (##)
-        if line.startswith("## "):
-            # Save previous section if it exists
-            if current_section:
-                section_text = "\n".join(current_section)
-                if section_text.strip():
-                    documents.append(
-                        Document(
-                            text=section_text,
-                            metadata={
-                                "source": str(source_path),
-                                "section": current_title,
-                            },
-                        )
-                    )
-
-            current_title = line[3:].strip()  # Remove "## " prefix
-            current_section = [line]
-        else:
-            current_section.append(line)
-
-    # Don't forget the last section
-    if current_section:
-        section_text = "\n".join(current_section)
-        if section_text.strip():
-            documents.append(
-                Document(
-                    text=section_text,
-                    metadata={"source": str(source_path), "section": current_title},
-                )
-            )
-
-    return documents
-
-
-def load_markdown_files(directory: str) -> list[Document]:
-    """
-    Load and process markdown files from a directory
-
-    Args:
-        directory: Path to the documents directory
-    Returns:
-        List of Document objects
-    """
-    documents = []
-    for path in Path(directory).rglob("*.md"):
-        with open(path, "r", encoding="utf-8") as f:
-            content = f.read()
-            documents.extend(split_markdown_by_headers(content, str(path)))
-    return documents
+from llama_index.core import VectorStoreIndex
+from config import init_settings, LLM
+from markdown_processor import load_markdown_files
+from query_engine import create_query_engine_with_validation
 
 
 def main():
+    # Initialize global settings
+    init_settings()
+
     # Load and process all markdown files
     documents = load_markdown_files("docs")
 
     # Create vector index from documents
     index = VectorStoreIndex.from_documents(documents)
 
-    # Configure query engine with specific parameters
-    query_engine = index.as_query_engine(
-        similarity_top_k=8,  # Number of relevant chunks to use (balance between context and precision)
-        response_mode="tree_summarize",  # Use hierarchical summarization for more coherent responses
-        system_prompt="""Vous êtes un assistant expert qui doit répondre aux questions en utilisant UNIQUEMENT les informations des documents fournis.
-    Si vous voyez une information pertinente dans les documents, même si elle n'est pas formulée exactement comme la question, utilisez-la.
-    Cherchez particulièrement les sections qui contiennent des informations liées à la question, même si les termes exacts ne correspondent pas.""",
-    )
+    # Create query engine with validation
+    query_engine = create_query_engine_with_validation(index, LLM)
 
     # Main interaction loop
+    print("\nAssistant RAG initialisé. Posez vos questions sur les documents !")
+
     while True:
         question = input("\nVotre question (ou 'q' pour quitter) : ")
         if question.lower() == "q":
             break
 
-        # DEBUG SECTION START
-        # This section helps understand which documents are being used for answers
-        # retriever = index.as_retriever(similarity_top_k=5)
-        # nodes = retriever.retrieve(question)
-        # print("\nSections pertinentes trouvées :")
-        # for i, node in enumerate(nodes, 1):
-        #     print(f"\nSection {i}:")
-        #     print(f"Source: {node.metadata['source']}")
-        #     print(f"Section: {node.metadata['section']}")
-        #     print(f"Score: {node.score if hasattr(node, 'score') else 'N/A'}")
-        #     print("Contenu:", node.text[:200], "...")
-        # DEBUG SECTION END
-
         # Get and display the response
-        response = query_engine.query(question)
+        response = query_engine(question)
         print("\nRéponse :", response)
 
 

--- a/src/markdown_processor.py
+++ b/src/markdown_processor.py
@@ -1,0 +1,89 @@
+"""
+Module pour le traitement des fichiers Markdown.
+Contient les fonctions de chargement et de découpage des documents.
+
+Markdown processing module.
+Contains functions for loading and splitting documents.
+"""
+
+from pathlib import Path
+from llama_index.core import Document
+
+
+def split_markdown_by_headers(content: str, source_path: str) -> list[Document]:
+    """
+    Enhanced markdown content splitter that preserves hierarchy and handles code blocks.
+    Only splits at level 2 headers (##) but preserves subheaders in content.
+
+    Args:
+        content: Raw markdown content
+        source_path: Path to the source file
+    Returns:
+        List of Document objects
+    """
+    documents = []
+    current_section = []
+    current_title = "Introduction"  # Default title if section doesn't have title
+    in_code_block = False
+
+    for line in content.split("\n"):
+        # Handle code blocks
+        if line.startswith("```"):
+            in_code_block = not in_code_block
+            current_section.append(line)
+            continue
+
+        if in_code_block:
+            current_section.append(line)
+            continue
+
+        # Only split on level 2 headers (##)
+        if line.startswith("## "):
+            # Save previous section if it exists
+            if current_section:
+                section_text = "\n".join(current_section)
+                if section_text.strip():
+                    documents.append(
+                        Document(
+                            text=section_text,
+                            metadata={
+                                "source": str(source_path),
+                                "section": current_title,
+                            },
+                        )
+                    )
+
+            current_title = line[3:].strip()  # Remove "## " prefix
+            current_section = [line]
+        else:
+            current_section.append(line)
+
+    # Don't forget the last section
+    if current_section:
+        section_text = "\n".join(current_section)
+        if section_text.strip():
+            documents.append(
+                Document(
+                    text=section_text,
+                    metadata={"source": str(source_path), "section": current_title},
+                )
+            )
+
+    return documents
+
+
+def load_markdown_files(directory: str) -> list[Document]:
+    """
+    Load and process markdown files from a directory
+
+    Args:
+        directory: Path to the documents directory
+    Returns:
+        List of Document objects
+    """
+    documents = []
+    for path in Path(directory).rglob("*.md"):
+        with open(path, "r", encoding="utf-8") as f:
+            content = f.read()
+            documents.extend(split_markdown_by_headers(content, str(path)))
+    return documents

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -1,0 +1,77 @@
+# prompts.py
+
+"""
+Ce fichier contient tous les prompts utilisés dans le système RAG.
+Les prompts sont organisés par fonction et incluent des commentaires explicatifs.
+
+This file contains all the prompts used in the RAG system.
+Prompts are organized by function and include explanatory comments.
+"""
+
+
+def get_validation_prompt(question: str, context: str) -> str:
+    """
+    Generates the prompt for validating passage relevance.
+
+    Args:
+        question: The user's question
+        context: The retrieved text passages
+
+    Returns:
+        str: The formatted validation prompt
+    """
+    return f"""INSTRUCTION : Vous êtes un vérificateur qui valide si les documents fournis contiennent les informations nécessaires pour répondre à la question.
+
+Question : {question}
+
+Documents à vérifier :
+{context}
+
+RÈGLES DE VALIDATION :
+1. Pour les questions sur "comment faire" ou les tutoriels :
+   - Les documents doivent contenir des instructions détaillées
+   - Un simple exemple n'est pas suffisant
+
+2. Pour les questions sur des tâches ou procédures :
+   - Les documents peuvent contenir les informations sous différentes sections
+   - Les horaires spécifiques et "selon disponibilités" sont considérés comme pertinents
+   - Une liste de tâches reliées à la période demandée est suffisante
+
+3. Pour les questions sur des définitions ou concepts :
+   - Les documents doivent contenir explicitement l'information
+   - Les mentions indirectes ne sont pas suffisantes
+
+4. Pour les questions générales :
+   - Si les documents contiennent des informations partielles mais utiles : répondez OUI
+   - Si les documents ne contiennent aucune information pertinente : répondez NON
+
+La question peut-elle être répondue avec les informations des documents (OUI ou NON) ?"""
+
+
+def get_response_prompt() -> str:
+    """
+    Returns the system prompt for response generation.
+
+    Returns:
+        str: The system prompt for response generation
+    """
+    return """INSTRUCTION : Vous êtes un assistant qui répond aux questions en utilisant les informations des documents fournis.
+
+RÈGLES IMPORTANTES :
+1. Pour les questions techniques ou conceptuelles :
+   - Ne fournissez QUE les informations explicitement dans les documents
+   - Ne complétez PAS avec vos connaissances
+
+2. Pour les questions sur des tâches ou procédures :
+   - Rassemblez les informations pertinentes de différentes sections
+   - Organisez la réponse de manière chronologique si possible
+   - Mentionnez les conditions (horaires spécifiques, selon disponibilités)
+
+3. Pour toute réponse :
+   - Restez fidèle au niveau de détail des documents
+   - N'ajoutez pas d'interprétations personnelles
+   - Si l'information est incomplète, précisez-le
+
+4. Si vous ne pouvez pas répondre : dites-le clairement
+
+Répondez maintenant à la question en suivant ces règles :"""

--- a/src/query_engine.py
+++ b/src/query_engine.py
@@ -1,0 +1,84 @@
+"""
+Module pour le moteur de requête.
+Contient la logique de validation et de génération des réponses.
+
+Query engine module.
+Contains the validation logic and response generation.
+"""
+
+from llama_index.core import VectorStoreIndex
+from llama_index.llms.ollama import Ollama
+from prompts import get_validation_prompt, get_response_prompt
+from config import TOP_K
+
+
+def create_query_engine_with_validation(index: VectorStoreIndex, llm: Ollama):
+    """
+    Creates an enhanced query engine that validates the relevance of retrieved passages
+    before generating a response. This helps ensure that responses are only generated
+    when relevant information is found in the documents.
+
+    Args:
+        index (VectorStoreIndex): The vector store index containing the document embeddings
+        llm (Ollama): The LLM instance used for both validation and response generation
+
+    Returns:
+        Callable: A query function that includes relevance validation
+    """
+
+    def check_relevance(question: str, nodes) -> bool:
+        """
+        Validates if the retrieved passages contain relevant information for the question.
+        Uses the LLM to perform a binary classification task.
+
+        Args:
+            question (str): The user's question
+            nodes: Retrieved document nodes from the vector store
+
+        Returns:
+            bool: True if the passages are deemed relevant, False otherwise
+        """
+        context = "\n\n".join(
+            [f"Passage {i + 1}:\n{node.text}" for i, node in enumerate(nodes)]
+        )
+
+        # The classification prompt is designed to:
+        # 1. Be strict about relevance
+        # 2. Handle different types of questions (how-to, definitions, procedures)
+        # 3. Consider information spread across multiple passages
+        # Get the validation prompt from prompts.py
+        prompt = get_validation_prompt(question, context)
+        # Get classification from LLM and check for positive response
+        response = llm.complete(prompt).text.strip().upper()
+        return "OUI" in response
+
+    # Create base query engine with specific parameters
+    base_query_engine = index.as_query_engine(
+        similarity_top_k=TOP_K,
+        response_mode="tree_summarize",
+        system_prompt=get_response_prompt(),
+    )
+
+    def query_with_validation(question: str):
+        """
+        Enhanced query function that includes relevance validation before generating responses.
+
+        Args:
+            question (str): The user's question
+
+        Returns:
+            str: Either the answer or a message indicating no relevant information found
+        """
+        # First retrieve relevant nodes
+        retriever = index.as_retriever(similarity_top_k=8)
+        nodes = retriever.retrieve(question)
+
+        # Check if retrieved passages are relevant
+        if check_relevance(question, nodes):
+            # If relevant, use base query engine to generate response
+            return base_query_engine.query(question)
+        else:
+            # If not relevant, return standard "no information" message
+            return "Je ne trouve pas dans les documents les informations nécessaires pour répondre à cette question."
+
+    return query_with_validation


### PR DESCRIPTION
feat(experimental): add relevance validation for retrieved passages

Add a two-step response process:
1. First validate if retrieved passages are actually relevant to the query
2. Only generate response if passages contain pertinent information

Note: This is an experimental feature. Results may vary and further tuning of validation prompts and thresholds might be needed.

Technical changes:
- New validation prompt system
- Separate prompt into modular files
- Structured validation rules for different question types